### PR TITLE
Add conflict with yourepo version of tweak

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,8 @@
 Package: com.greg0109.forwardnotifier
 Name: ForwardNotifier
 Depends: mobilesubstrate, sshpass, openssh, applist, preferenceloader, curl
+Conflicts: com.yourepo.greg0109.forwardnotifier8
+Replaces: com.yourepo.greg0109.forwardnotifier8
 Version: 1.4.1
 Architecture: iphoneos-arm
 Description: Forward Notifications to your PC!


### PR DESCRIPTION
Makes it easier for users of the yourepo version to switch to the chairz repo version by automatically forcing removal of the yourepo version. 
This will also result in the uninstallation of the corresponding Activator extension unless you add the field "Provides: com.yourepo.greg0109.forwardnotifier8". My suggestion would be shipping the extension with the main package but that is your choice. 